### PR TITLE
Need to change mask for month in updateMonthLabelMonth

### DIFF
--- a/RDVCalendarView/RDVCalendarView.m
+++ b/RDVCalendarView/RDVCalendarView.m
@@ -367,7 +367,7 @@
 
 - (void)updateMonthLabelMonth:(NSDateComponents*)month {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    formatter.dateFormat = @"MMMM yyyy";
+    formatter.dateFormat = @"LLLL yyyy";
     
     NSDate *date = [month.calendar dateFromComponents:month];
     self.monthLabel.text = [formatter stringFromDate:date];


### PR DESCRIPTION
The following functions defines month label:
- (void)updateMonthLabelMonth:(NSDateComponents*)month {
  NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
  formatter.dateFormat = @"MMMM yyyy";
  ....

According to Unicode Technical Standard #35, mask for STANDALONE month should be 'LLLL', not 'MMMM'. There is no difference in English language, but there is for example in Russian. For the old mask October is written as  'октября 2014' (incorrect), for new mask it is  'Октябрь 2014' (correct).
