### PR TITLE
Refactored showPreviousMonth() and showNextMonth to keep self.month cons...

### DIFF
--- a/RDVCalendarView/RDVCalendarView.m
+++ b/RDVCalendarView/RDVCalendarView.m
@@ -631,20 +631,42 @@
 
 - (void)showCurrentMonth {
     [[self month] setMonth:[[self currentDay] month]];
-    
+    [[self month] setYear:[[self currentDay] year]];
+ 
     [self setDisplayedMonth:[self month]];
 }
 
 - (void)showPreviousMonth {
-    NSInteger month = [[self month] month] - 1;
-    [[self month] setMonth:month];
+    NSCalendar *calendar = [self calendar];
+    NSDateComponents *inc = [[NSDateComponents alloc] init];
+    inc.month = -1;
     
+    NSDate *date = [calendar dateFromComponents:self.month];
+    NSDate *newDate = [calendar dateByAddingComponents:inc toDate:date options:0];
+    
+    self.month = [calendar components:NSYearCalendarUnit|
+                  NSMonthCalendarUnit|
+                  NSDayCalendarUnit|
+                  NSWeekdayCalendarUnit|
+                  NSCalendarCalendarUnit fromDate:newDate];   
+ 
     [self setDisplayedMonth:[self month]];
 }
 
 - (void)showNextMonth {
-    NSInteger month = [[self month] month] + 1;
-    [[self month] setMonth:month];
+
+    NSCalendar *calendar = [self calendar];
+    NSDateComponents *inc = [[NSDateComponents alloc] init];
+    inc.month = 1;
+    
+    NSDate *date = [calendar dateFromComponents:self.month];
+    NSDate *newDate = [calendar dateByAddingComponents:inc toDate:date options:0];
+    
+    self.month = [calendar components:NSYearCalendarUnit|
+                  NSMonthCalendarUnit|
+                  NSDayCalendarUnit|
+                  NSWeekdayCalendarUnit|
+                  NSCalendarCalendarUnit fromDate:newDate];
     
     [self setDisplayedMonth:[self month]];
 }


### PR DESCRIPTION
Variable self.month is a public property in class RDVCalendarView. This means that it can be used by external classes, and, therefore, it should be always consistent. The field self.month.year represents year currently shown inside calendar. The problem is that functions showPrevMonth() and showNextMonth() don't update this field. They only update self.month.month. Thus, when I try to access self. month.year from my application, I get inconsistent results if the calendar is scrolled beyond current year.

I understand that I could possibly analyse self.month.month and detect an overflow, but my point is that it's the responsibility of component to keep its public variables consistent.

Thus, I suggest a patch that fixes the problem by recomputing self.month in these functions.
